### PR TITLE
feat: add organization support amount

### DIFF
--- a/src/dynamo/service.ts
+++ b/src/dynamo/service.ts
@@ -44,9 +44,7 @@ export async function handleHywepUsers(newItem: any): Promise<void> {
     await sendNewRecruitmentEmail(email, name, matchingRecruits);
     await sendSlackMessage(
       SLACK_TYPE.SEND_EMAIL,
-      `${
-        process.env.NODE_ENV !== 'prod' ? `[${process.env.NODE_ENV}] ` : ''
-      }진행 공고 이메일 전송 완료:\n- 이름: ${name}\n- 이메일: ${email}\n`,
+      `[${process.env.NODE_ENV}] 진행 공고 이메일 전송 완료:\n- 이름: ${name}\n- 이메일: ${email}\n`,
     );
   }
 }
@@ -68,13 +66,12 @@ export async function handleHywepRecruit(newItem: any): Promise<void> {
     interviewInfo,
     internshipDetails,
     announcedMajors,
+    organizationSupportAmount,
   } = newItem;
 
   await sendSlackMessage(
     SLACK_TYPE.NEW_RECRUIT,
-    `${
-      process.env.NODE_ENV !== 'prod' ? `[${process.env.NODE_ENV}] ` : ''
-    }신규 공고:\n- 기관: ${organizationName}\n- 공고상 전공: ${qualifications?.major}\n- 전공: ${majors}\n`,
+    `[${process.env.NODE_ENV}] 신규 공고:\n- 기관: ${organizationName}\n- 공고상 전공: ${qualifications?.major}\n- 전공: ${majors}\n`,
   );
 
   const matchingUsers = await findMatchingUsers(majors, selectionInfo);
@@ -95,6 +92,7 @@ export async function handleHywepRecruit(newItem: any): Promise<void> {
       interviewInfo,
       internshipDetails,
       announcedMajors,
+      organizationSupportAmount,
     );
     await sendEmail(
       email,
@@ -104,4 +102,8 @@ export async function handleHywepRecruit(newItem: any): Promise<void> {
       html,
     );
   }
+  await sendSlackMessage(
+    SLACK_TYPE.SEND_EMAIL,
+    `[${process.env.NODE_ENV}] 신규 공고 이메일 전송 완료:\n- 기관: ${organizationName}\n- 발송 건수: ${matchingUsers.length}\n`,
+  );
 }

--- a/src/mail/service.ts
+++ b/src/mail/service.ts
@@ -80,6 +80,7 @@ export function generateRecruitByTagDetails(recruits: any[]): string {
         interviewInfo,
         internshipDetails,
         announcedMajors,
+        organizationSupportAmount,
       } = recruit;
 
       return generateInternshipDetailEmailHTML(
@@ -96,6 +97,7 @@ export function generateRecruitByTagDetails(recruits: any[]): string {
         interviewInfo,
         internshipDetails,
         announcedMajors,
+        organizationSupportAmount,
       );
     })
     .join('<hr style="border: 1px solid #ddd; margin: 20px 0;">');
@@ -112,47 +114,68 @@ function generateRecruitDetails(recruits: any[]): string {
         department,
         internshipDetails,
         qualifications,
+        organizationSupportAmount,
+        recruitCount,
       } = recruit;
 
       const borderStyle =
         index !== recruits.length - 1 ? 'border-bottom: 1px solid #ddd;' : '';
 
+      // Generate HTML snippets for each field
+      const organizationSizeHtml =
+        organizationSize === '대기업'
+          ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">조직 규모:</strong> <span style="color: red; font-weight: bold;">${organizationSize}</span></li>`
+          : '';
+
+      const organizationNameHtml = organizationName
+        ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">기관 이름:</strong> <span style="color: #000;">${organizationName}</span></li>`
+        : '';
+
+      const departmentHtml = department
+        ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">부서:</strong> <span style="color: #000;">${department}</span></li>`
+        : '';
+
+      const jobTitleHtml = internshipDetails?.jobTitle
+        ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">직무명:</strong> <span style="color: #000;">${internshipDetails.jobTitle}</span></li>`
+        : '';
+
+      const qualificationsHtml = qualifications?.major
+        ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">전공:</strong> <span style="color: #000;">${qualifications.major.join(
+            ', ',
+          )}</span></li>`
+        : '';
+
+      const locationHtml = location
+        ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">위치:</strong> <span style="color: #000;">${location}</span></li>`
+        : '';
+
+      const organizationSupportAmountHtml =
+        organizationSupportAmount?.period &&
+        organizationSupportAmount?.amount &&
+        organizationSupportAmount.amount !== 0
+          ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">급여:</strong> <span style="color: #000;">${organizationSupportAmount.period} ${organizationSupportAmount.amount.toLocaleString()}</span></li>`
+          : '';
+
+      const recruitCountHtml = recruitCount
+        ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">모집 인원:</strong> <span style="color: #000;">${recruitCount}</span></li>`
+        : '';
+
+      const applicationDeadlineHtml = applicationDeadline
+        ? `<li><strong style="color: #0056b3;">지원 마감일:</strong> <span style="color: #000;">${applicationDeadline}</span></li>`
+        : '';
+
       return `
         <div style="margin: 20px 0; padding-bottom: 20px; ${borderStyle}">
           <ul style="list-style: none; padding: 0; margin: 0;">
-            ${
-              organizationSize === '대기업'
-                ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">조직 규모:</strong> <span style="color: red; font-weight: bold;">${organizationSize}</span></li>`
-                : ''
-            }
-            <li style="margin-bottom: 10px;"><strong style="color: #0056b3;">기관 이름:</strong> <span style="color: #000;">${organizationName}</span></li>
-            ${
-              department
-                ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">부서:</strong> <span style="color: #000;">${department}</span></li>`
-                : ''
-            }
-            ${
-              internshipDetails?.jobTitle
-                ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">직무명:</strong> <span style="color: #000;">${internshipDetails.jobTitle}</span></li>`
-                : ''
-            }
-            ${
-              qualifications?.major
-                ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">전공:</strong> <span style="color: #000;">${qualifications.major.join(
-                    ', ',
-                  )}</span></li>`
-                : ''
-            }
-            ${
-              location
-                ? `<li style="margin-bottom: 10px;"><strong style="color: #0056b3;">위치:</strong> <span style="color: #000;">${location}</span></li>`
-                : ''
-            }
-            ${
-              applicationDeadline
-                ? `<li><strong style="color: #0056b3;">지원 마감일:</strong> <span style="color: #000;">${applicationDeadline}</span></li>`
-                : ''
-            }
+            ${organizationSizeHtml}
+            ${organizationNameHtml}
+            ${departmentHtml}
+            ${jobTitleHtml}
+            ${qualificationsHtml}
+            ${locationHtml}
+            ${recruitCountHtml}
+            ${organizationSupportAmountHtml}
+            ${applicationDeadlineHtml}
           </ul>
         </div>
       `;
@@ -208,6 +231,7 @@ export function generateInternshipEmailHTML(
   interviewInfo,
   internshipDetails,
   announcedMajors,
+  organizationSupportAmount,
 ) {
   const organizationSizeHtml =
     organizationSize === '대기업'
@@ -249,6 +273,14 @@ export function generateInternshipEmailHTML(
   const organizationNameHtml = organizationName
     ? `<li style="margin-bottom: 10px"><strong style="color: #0056b3;">기관 이름:</strong> <span style="color: #000;">${organizationName}</span></li>`
     : '';
+
+  const organizationSupportAmountHtml =
+    organizationSupportAmount &&
+    organizationSupportAmount.period &&
+    organizationSupportAmount.amount &&
+    organizationSupportAmount.amount !== 0
+      ? `<li style="margin-bottom: 10px"><strong style="color: #0056b3;">급여:</strong> <span style="color: #000;">${organizationSupportAmount.period} ${organizationSupportAmount.amount.toLocaleString()}</span></li>`
+      : '';
 
   const qualificationsHtml = qualifications
     ? `<ul style="list-style: none; padding: 0; margin: 0;">
@@ -316,6 +348,7 @@ export function generateInternshipEmailHTML(
             ${locationHtml}
             ${typeHtml}
             ${recruitCountHtml}
+            ${organizationSupportAmountHtml}
             ${applicationDeadlineHtml}
             ${startDateHtml}
             ${endDateHtml}
@@ -353,6 +386,7 @@ export function generateInternshipDetailEmailHTML(
   interviewInfo,
   internshipDetails,
   announcedMajors,
+  organizationSupportAmount,
 ) {
   const organizationSizeHtml =
     organizationSize === '대기업'
@@ -394,6 +428,14 @@ export function generateInternshipDetailEmailHTML(
   const organizationNameHtml = organizationName
     ? `<li style="margin-bottom: 10px"><strong style="color: #0056b3;">기관 이름:</strong> <span style="color: #000;">${organizationName}</span></li>`
     : '';
+
+  const organizationSupportAmountHtml =
+    organizationSupportAmount &&
+    organizationSupportAmount.period &&
+    organizationSupportAmount.amount &&
+    organizationSupportAmount.amount !== 0
+      ? `<li style="margin-bottom: 10px"><strong style="color: #0056b3;">급여:</strong> <span style="color: #000;">${organizationSupportAmount.period} ${organizationSupportAmount.amount.toLocaleString()}</span></li>`
+      : '';
 
   const qualificationsHtml = qualifications
     ? `<ul style="list-style: none; padding: 0; margin: 0;">
@@ -451,6 +493,7 @@ export function generateInternshipDetailEmailHTML(
             ${locationHtml}
             ${typeHtml}
             ${recruitCountHtml}
+            ${organizationSupportAmountHtml}
             ${applicationDeadlineHtml}
             ${startDateHtml}
             ${endDateHtml}

--- a/src/opensearch/query.ts
+++ b/src/opensearch/query.ts
@@ -50,6 +50,7 @@ export async function searchMatchingRecruits(
         query,
         sort: [{ applicationDeadline: { order: 'asc' } }],
       },
+      size: 1000,
     });
 
     const uniqueResults = new Map<string, any>();
@@ -94,6 +95,7 @@ export async function findMatchingRecruits(
       query,
       sort: [{ applicationDeadline: { order: 'asc' } }],
     },
+    size: 1000,
   });
 
   return response.body.hits.hits.map((hit: any) => hit._source);
@@ -108,7 +110,7 @@ export async function findMatchingUsers(
   }));
 
   const gradeShouldQueries = recruitGrades.map((grade) => ({
-    match: { grade: grade.toString() },
+    match: { grade: grade },
   }));
 
   let mustQueries: any[];
@@ -133,6 +135,7 @@ export async function findMatchingUsers(
     body: {
       query,
     },
+    size: 1000,
   });
 
   return response.body.hits.hits.map((hit: any) => hit._source);

--- a/src/schedule/service.ts
+++ b/src/schedule/service.ts
@@ -29,7 +29,10 @@ export async function handleScheduledEvent(event: any): Promise<void> {
 
       if (matchingRecruits.length > 0) {
         await sendRecruitmentByTagEmail(email, name, matchingRecruits);
-        await sendSlackMessage(SLACK_TYPE.SEND_EMAIL, `Email sent to ${email}`);
+        await sendSlackMessage(
+          SLACK_TYPE.SEND_EMAIL,
+          `희망 키워드 공고 이메일 전송 완료:\n- 이름수: ${name}\n- 이메일: ${email}\n`,
+        );
       } else {
         console.log(`No matches for user: ${email}`);
       }


### PR DESCRIPTION
# feat: add slack messaging and organization support amount in email notifications

## **Description**

1. **Slack Messaging:**
   - Provide environment of the message sent (dev, qa, prod)

2. **Organization Support Amount in Emails:**
   - Integrated `organizationSupportAmount` into email notifications, providing details about salary amounts and periods where applicable.
   - Ensured dynamic rendering of this field in all relevant email templates.

3. **Query Limit Adjustments:**
   - Updated OpenSearch queries to set a retrieval size of 1000 for handling larger result sets efficiently.
---

## **Related Issue**


---

## **Motivation and Context**

- Improve clarity in Slack notifications.
- Provide comprehensive information to recipients via email, including monetary support details that are critical to decision-making.
- Enhance the query capabilities to support higher data volume processing.

---

## **How Has This Been Tested?**

- **Unit Testing:**
  - Verified email content for different recruitment scenarios, ensuring the inclusion of `organizationSupportAmount` when applicable.
  - Tested Slack messaging for various events to confirm the accuracy and consistency of notifications.

- **Integration Testing:**
  - Deployed in the development environment and tested end-to-end flows, including:
    - Handling tag-based recruitment email dispatch.
    - Processing newly created recruitments and sending corresponding emails and Slack notifications.

- **Manual Testing:**
  - Manually triggered workflows for scheduled events and recruitment updates to validate real-world scenarios.

---

## **Screenshots (if appropriate)**

N/A

---

## **Checklist**

- [x] My code follows the code style of this project.
- [x] My changes require updates to documentation.
- [ ] I have added documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---
