### PR TITLE
chore: export user table stream arn

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -118,4 +118,13 @@ resources:
                 KeyType: HASH
             Projection:
               ProjectionType: ALL
+  Outputs:
+    HywepUserStreamArn:
+      Description: The ARN of the DynamoDB Stream for UsersTable
+      Value:
+        Fn::GetAtt:
+          - UsersTable
+          - StreamArn
+      Export:
+        Name: HywepUserStreamArn-${opt:stage, 'dev'}
 


### PR DESCRIPTION
# Export user table stream arn

## **Description**

This pull request adds the export of the DynamoDB Stream ARN for the `UsersTable` in the `serverless.yml` configuration. The following changes have been made:

- Added the output `HywepUserStreamArn` to export the DynamoDB Stream ARN for `UsersTable`.
- Ensures the ARN is accessible via `HywepUserStreamArn-${opt:stage, 'dev'}`.

---

## **Related Issue**

#7 

---

## **Motivation and Context**

This change is necessary to make the DynamoDB Stream ARN for `UsersTable` available for use in other services or infrastructure configurations. By exporting the ARN, it simplifies cross-service referencing and deployment consistency.

---

## **How Has This Been Tested?**

The following testing methods were used:

1. **Manual Validation**:
   - Deployed the updated configuration to the `dev` stage.
   - Confirmed the DynamoDB Stream ARN was correctly exported via the CloudFormation Outputs in the AWS Console.

2. **Unit Testing**:
   - Validated that the expected output matches the generated CloudFormation template.

---

## **Screenshots (if appropriate)**

N/A

---

## **Checklist**

- [x] My code follows the code style of this project.
- [x] My changes require updates to documentation.
- [x] I have added documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

