### PR TITLE
feat: filter users by isActive

### DIFF
--- a/src/dynamo/query.ts
+++ b/src/dynamo/query.ts
@@ -4,7 +4,7 @@ import { unmarshall } from '@aws-sdk/util-dynamodb';
 
 const dynamodb = new DynamoDBClient({ region: 'ap-northeast-2' });
 
-export async function getAllUsers(): Promise<any[]> {
+export async function getAllActiveUsers(): Promise<any[]> {
   const allUsers: any[] = [];
   let lastEvaluatedKey: Record<string, any> | undefined = undefined;
 
@@ -13,6 +13,13 @@ export async function getAllUsers(): Promise<any[]> {
       new ScanCommand({
         TableName: DYNAMO_TABLE.USERS,
         ExclusiveStartKey: lastEvaluatedKey,
+        FilterExpression: '#isActive = :trueValue',
+        ExpressionAttributeNames: {
+          '#isActive': 'isActive',
+        },
+        ExpressionAttributeValues: {
+          ':trueValue': { BOOL: true },
+        },
       }),
     );
 

--- a/src/dynamo/service.ts
+++ b/src/dynamo/service.ts
@@ -1,7 +1,10 @@
 import { DynamoDBStreamEvent } from 'aws-lambda';
 import { unmarshall } from '@aws-sdk/util-dynamodb';
 import { AttributeValue } from '@aws-sdk/client-dynamodb';
-import { findMatchingRecruits, findMatchingUsers } from '../opensearch/query';
+import {
+  findMatchingActiveUsers,
+  findMatchingRecruits,
+} from '../opensearch/query';
 import {
   generateInternshipEmailHTML,
   sendEmail,
@@ -74,7 +77,7 @@ export async function handleHywepRecruit(newItem: any): Promise<void> {
     `[${process.env.NODE_ENV}] 신규 공고:\n- 기관: ${organizationName}\n- 공고상 전공: ${qualifications?.major}\n- 전공: ${majors}\n`,
   );
 
-  const matchingUsers = await findMatchingUsers(majors, selectionInfo);
+  const matchingUsers = await findMatchingActiveUsers(majors, selectionInfo);
 
   for (const { name, email } of matchingUsers) {
     const html = generateInternshipEmailHTML(

--- a/src/opensearch/query.ts
+++ b/src/opensearch/query.ts
@@ -101,7 +101,7 @@ export async function findMatchingRecruits(
   return response.body.hits.hits.map((hit: any) => hit._source);
 }
 
-export async function findMatchingUsers(
+export async function findMatchingActiveUsers(
   recruitMajors: string[],
   recruitGrades: number[],
 ): Promise<any[]> {
@@ -127,6 +127,7 @@ export async function findMatchingUsers(
   const query = {
     bool: {
       must: mustQueries,
+      filter: [{ term: { isActive: true } }],
     },
   };
 

--- a/src/schedule/service.ts
+++ b/src/schedule/service.ts
@@ -1,4 +1,4 @@
-import { getAllUsers } from '../dynamo/query';
+import { getAllActiveUsers } from '../dynamo/query';
 import { searchMatchingRecruits } from '../opensearch/query';
 import { sendRecruitmentByTagEmail } from '../mail/service';
 import { sendSlackMessage } from '../slack/service';
@@ -14,7 +14,7 @@ export async function handleScheduledEvent(event: any): Promise<void> {
 
   try {
     console.log('Processing scheduled event:', JSON.stringify(event, null, 2));
-    const users = await getAllUsers();
+    const users = await getAllActiveUsers();
 
     for (const user of users) {
       const { email, name, tags } = user;


### PR DESCRIPTION
# Filter users by isActive

## **Description**

This pull request ensures only active users are retrieved and processed when sending email. 

- Replaced `getAllUsers` with `getAllActiveUsers` to filter users by `isActive: true`.
- Updated DynamoDB query to include `FilterExpression` for active users.
- Replaced `findMatchingUsers` with `findMatchingActiveUsers` in the relevant functions.
- Modified OpenSearch queries to include a filter for active users (`isActive: true`).
- Updated scheduled event handler to use `getAllActiveUsers`.

---

## **Related Issue**

#6 

---

## **Motivation and Context**

These changes are necessary to ensure that inactive users are excluded from email notifications.

---

## **How Has This Been Tested?**

The following testing methods were used:

1. **Unit Testing**:
   - Updated tests for `getAllActiveUsers` to validate filtering logic.
   - Ensured `findMatchingActiveUsers` returns correct results with the `isActive` filter applied.

2. **Integration Testing**:
   - Verified scheduled event handler processes only active users.
   - Tested email notifications and OpenSearch queries to confirm they exclude inactive users.

3. **Manual Validation**:
   - Deployed to the `dev` stage and validated the changes using test data.

---

## **Screenshots (if appropriate)**

---

## **Checklist**

- [x] My code follows the code style of this project.
- [x] My changes require updates to documentation.
- [x] I have added documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

